### PR TITLE
Janus multiple msg transactions

### DIFF
--- a/janus.go
+++ b/janus.go
@@ -179,9 +179,6 @@ func (gateway *Gateway) recv() {
 
 		// Pass message on from here
 		if base.ID == "" || transactionUsed {
-			if transactionUsed {
-				fmt.Printf("msg: %v", msg)
-			}
 			// Is this a Handle event?
 			if base.Handle == 0 {
 				// Error()

--- a/janus.go
+++ b/janus.go
@@ -40,6 +40,7 @@ type Gateway struct {
 	conn            *websocket.Conn
 	nextTransaction uint64
 	transactions    map[uint64]chan interface{}
+	transactionsUsed    map[uint64]bool
 
 	sendChan chan []byte
 	writeMu  sync.Mutex
@@ -57,6 +58,7 @@ func Connect(wsURL string) (*Gateway, error) {
 	gateway := new(Gateway)
 	gateway.conn = conn
 	gateway.transactions = make(map[uint64]chan interface{})
+	gateway.transactionsUsed = make(map[uint64]bool)
 	gateway.Sessions = make(map[uint64]*Session)
 
 	gateway.sendChan = make(chan []byte, 100)
@@ -77,6 +79,7 @@ func (gateway *Gateway) send(msg map[string]interface{}, transaction chan interf
 	msg["transaction"] = strconv.FormatUint(id, 10)
 	gateway.Lock()
 	gateway.transactions[id] = transaction
+	gateway.transactionsUsed[id] = false
 	gateway.Unlock()
 
 	data, err := json.Marshal(msg)
@@ -165,8 +168,21 @@ func (gateway *Gateway) recv() {
 			continue // Decode error
 		}
 
+		var transactionUsed bool
+		if base.ID != "" {
+			id, _ := strconv.ParseUint(base.ID, 10, 64)
+			gateway.Lock()
+			transactionUsed = gateway.transactionsUsed[id]
+			fmt.Printf("transactionUsed:", transactionUsed, id)
+			gateway.Unlock()
+
+		}
+
 		// Pass message on from here
-		if base.ID == "" {
+		if base.ID == "" || transactionUsed {
+			if transactionUsed {
+				fmt.Printf("msg: %v", msg)
+			}
 			// Is this a Handle event?
 			if base.Handle == 0 {
 				// Error()
@@ -197,6 +213,7 @@ func (gateway *Gateway) recv() {
 			// Lookup Transaction
 			gateway.Lock()
 			transaction := gateway.transactions[id]
+			gateway.transactionsUsed[id] = true
 			gateway.Unlock()
 			if transaction == nil {
 				// Error()

--- a/janus.go
+++ b/janus.go
@@ -173,7 +173,6 @@ func (gateway *Gateway) recv() {
 			id, _ := strconv.ParseUint(base.ID, 10, 64)
 			gateway.Lock()
 			transactionUsed = gateway.transactionsUsed[id]
-			fmt.Printf("transactionUsed:", transactionUsed, id)
 			gateway.Unlock()
 
 		}
@@ -213,7 +212,10 @@ func (gateway *Gateway) recv() {
 			// Lookup Transaction
 			gateway.Lock()
 			transaction := gateway.transactions[id]
-			gateway.transactionsUsed[id] = true
+			switch msg.(type) {
+			case *EventMsg:
+				gateway.transactionsUsed[id] = true
+			}
 			gateway.Unlock()
 			if transaction == nil {
 				// Error()


### PR DESCRIPTION
With the current setup if multiple messages are return for the one transaction the sit in a channel and are never read by anyone. 

With this change the follow on message's go into the general msg pool.

A better change might be to return channel when send is called. 

some tests would probably be good too.