### PR TITLE
logger: do not write to stdout

### DIFF
--- a/janus.go
+++ b/janus.go
@@ -92,7 +92,7 @@ func (gateway *Gateway) send(msg map[string]interface{}, transaction chan interf
 
 	data, err := json.Marshal(msg)
 	if err != nil {
-		fmt.Printf("json.Marshal: %s\n", err)
+		log.Printf("json.Marshal: %s\n", err)
 		return
 	}
 
@@ -112,7 +112,7 @@ func (gateway *Gateway) send(msg map[string]interface{}, transaction chan interf
 		select {
 		case gateway.errors <- err:
 		default:
-			fmt.Printf("conn.Write: %s\n", err)
+			log.Printf("conn.Write: %s\n", err)
 		}
 
 		return
@@ -160,14 +160,14 @@ func (gateway *Gateway) recv() {
 			select {
 			case gateway.errors <- err:
 			default:
-				fmt.Printf("conn.Read: %s\n", err)
+				log.Printf("conn.Read: %s\n", err)
 			}
 
 			return
 		}
 
 		if err := json.Unmarshal(data, &base); err != nil {
-			fmt.Printf("json.Unmarshal: %s\n", err)
+			log.Printf("json.Unmarshal: %s\n", err)
 			continue
 		}
 
@@ -181,13 +181,13 @@ func (gateway *Gateway) recv() {
 
 		typeFunc, ok := msgtypes[base.Type]
 		if !ok {
-			fmt.Printf("Unknown message type received!\n")
+			log.Printf("Unknown message type received!\n")
 			continue
 		}
 
 		msg := typeFunc()
 		if err := json.Unmarshal(data, &msg); err != nil {
-			fmt.Printf("json.Unmarshal: %s\n", err)
+			log.Printf("json.Unmarshal: %s\n", err)
 			continue // Decode error
 		}
 
@@ -211,7 +211,7 @@ func (gateway *Gateway) recv() {
 				session := gateway.Sessions[base.Session]
 				gateway.Unlock()
 				if session == nil {
-					fmt.Printf("Unable to deliver message. Session gone?\n")
+					log.Printf("Unable to deliver message. Session gone?\n")
 					continue
 				}
 
@@ -220,7 +220,7 @@ func (gateway *Gateway) recv() {
 				handle := session.Handles[base.Handle]
 				session.Unlock()
 				if handle == nil {
-					fmt.Printf("Unable to deliver message. Handle gone?\n")
+					log.Printf("Unable to deliver message. Handle gone?\n")
 					continue
 				}
 


### PR DESCRIPTION
Fixes garbage being written to files that are created by clients piping to stdout:

```
$ hexdump -C foobar.mkv 
00000000  1a 45 df a3 a4 42 86 81  01 42 f7 81 01 42 f2 81  |.E...B...B...B..|
00000010  04 42 f3 81 08 42 82 89  6d 61 74 72 6f 73 6b 61  |.B...B..matroska|
00000020  00 42 87 81 04 42 85 81  02 18 53 80 67 01 ff ff  |.B...B....S.g...|
00000030  ff ff ff ff ff 15 49 a9  66 bf 2a d7 b1 83 0f 42  |......I.f.*....B|
00000040  40 4d 80 99 65 62 6d 6c  2d 67 6f 2e 77 65 62 6d  |@M..ebml-go.webm|
00000050  2e 42 6c 6f 63 6b 57 72  69 74 65 72 00 57 41 99  |.BlockWriter.WA.|
00000060  65 62 6d 6c 2d 67 6f 2e  77 65 62 6d 2e 42 6c 6f  |ebml-go.webm.Blo|
00000070  63 6b 57 72 69 74 65 72  00 16 54 ae 6b 40 82 ae  |ckWriter..T.k@..|
00000080  b6 53 6e 86 56 69 64 65  6f 00 d7 81 01 73 c5 88  |.Sn.Video....s..|
00000090  a6 84 47 a4 18 9d eb 99  86 90 56 5f 4d 50 45 47  |..G.......V_MPEG|
000000a0  34 2f 49 53 4f 2f 41 56  43 00 83 81 01 e0 88 b0  |4/ISO/AVC.......|
000000b0  82 05 00 ba 82 02 d0 ae  c8 53 6e 86 41 75 64 69  |.........Sn.Audi|
000000c0  6f 00 d7 81 02 73 c5 88  41 f2 7c c6 f3 87 5d 04  |o....s..A.|...].|
000000d0  86 87 41 5f 4f 50 55 53  00 63 a2 93 4f 70 75 73  |..A_OPUS.c..Opus|
000000e0  48 65 61 64 01 02 00 00  80 bb 00 00 00 00 00 83  |Head............|
000000f0  81 02 e1 8d b5 88 40 e7  70 00 00 00 00 00 9f 81  |......@.p.......|
00000100  02 63 6f 6e 6e 2e 52 65  61 64 3a 20 77 65 62 73  |.conn.Read: webs|                <------------------ ruh roh
00000110  6f 63 6b 65 74 3a 20 63  6c 6f 73 65 20 31 30 30  |ocket: close 100|
00000120  30 20 28 6e 6f 72 6d 61  6c 29 3a 20 69 6e 70 75  |0 (normal): inpu|
00000130  74 20 73 74 72 65 61 6d  20 64 6f 77 6e 0a        |t stream down.|
0000013e
```